### PR TITLE
Fix Import Syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ All formatting elements can either be used by themeselves which will render a Re
 ### Use as standalone component:
 
 ```jsx
-import FormattedMessage from 'react-i18next-components';
+import { FormattedMessage } from 'react-i18next-components';
 
 <FormattedMesage id="path.to.key" />;
 ```
@@ -51,7 +51,7 @@ import FormattedMessage from 'react-i18next-components';
 ### Use with render prop:
 
 ```jsx
-import FormattedMessage from 'react-i18next-components';
+import { FormattedMessage } from 'react-i18next-components';
 
 <FormattedMesage id="path.to.key">
   {text => (


### PR DESCRIPTION
## What did we change?
Updates the examples to show the correct syntax for importing `FormattedMessage`.

## Why are we doing this?
When we were trying to import the `FormattedMessage` component as though it were a default export (as shown in the first examples of the docs), we got errors. We figured out that the later examples are correct and that the component needs to be imported by name. This change updates the docs so that they're consistent and won't confuse others down the road.

## How was it tested?
N/A