### PR TITLE
Add FormattedDictionary component

### DIFF
--- a/__mocks__/react-i18next.js
+++ b/__mocks__/react-i18next.js
@@ -1,9 +1,7 @@
-const MOCKED_RETURN_VALUE = 'hello';
-
 export const withNamespaces = () => Component => {
   Component.defaultProps = {
     ...Component.defaultProps,
-    t: () => MOCKED_RETURN_VALUE,
+    t: (id, args) => `key: ${id} options: ${JSON.stringify(args)}`,
     i18n: {
       language: 'en',
     },

--- a/src/components/FormattedDictionary.js
+++ b/src/components/FormattedDictionary.js
@@ -1,0 +1,19 @@
+import { withNamespaces } from 'react-i18next';
+
+const looksLikeTranslation = value => typeof value === 'string';
+
+const FormattedDictionary = ({ t, options = {}, children, ...ids }) => {
+  const translations = {};
+
+  Object.entries(ids).forEach(([key, value]) => {
+    if (looksLikeTranslation(value))
+      translations[key] = t(value, options[key] || {});
+  });
+
+  return children(translations);
+};
+
+const FormattedDictionaryWrapper = withNamespaces()(FormattedDictionary);
+FormattedDictionaryWrapper.displayName = 'FormattedDictionary';
+
+export default FormattedDictionaryWrapper;

--- a/src/components/__tests__/FormattedDictionary.test.js
+++ b/src/components/__tests__/FormattedDictionary.test.js
@@ -1,0 +1,45 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import FormattedDictionary from '../FormattedDictionary';
+
+describe('<FormattedDictionary />', () => {
+  describe('when the component is passed a function as a child', () => {
+    it('renders the return of the function with the correct text', () => {
+      const MOCKED_RETURN_VALUE =
+        'key: name.key options: {} - key: header.key options: {}';
+      const wrapper = mount(
+        <FormattedDictionary name="name.key" header="header.key">
+          {({ name, header }) => (
+            <p>
+              {name} - {header}
+            </p>
+          )}
+        </FormattedDictionary>
+      );
+
+      expect(wrapper.contains(<p>{MOCKED_RETURN_VALUE}</p>)).toEqual(true);
+    });
+
+    it('handles options being passed', () => {
+      const MOCKED_RETURN_VALUE = `key: name.key options: {} - key: header.key options: ${JSON.stringify(
+        { num: 4 }
+      )}`;
+
+      const wrapper = mount(
+        <FormattedDictionary
+          name="name.key"
+          header="header.key"
+          options={{ header: { num: 4 } }}
+        >
+          {({ name, header }) => (
+            <p>
+              {name} - {header}
+            </p>
+          )}
+        </FormattedDictionary>
+      );
+
+      expect(wrapper.contains(<p>{MOCKED_RETURN_VALUE}</p>)).toEqual(true);
+    });
+  });
+});

--- a/src/components/__tests__/FormattedMessage.test.js
+++ b/src/components/__tests__/FormattedMessage.test.js
@@ -2,12 +2,22 @@ import React from 'react';
 import { mount } from 'enzyme';
 import FormattedMessage from '../FormattedMessage';
 
-const MOCKED_RETURN_VALUE = 'hello';
-
 describe('<FormattedMessage />', () => {
   describe('when the component is passed no child', () => {
     it('renders a fragment with the correct text', () => {
+      const MOCKED_RETURN_VALUE = 'key: key options: undefined';
       const wrapper = mount(<FormattedMessage id="key" />);
+
+      expect(wrapper.contains(MOCKED_RETURN_VALUE)).toEqual(true);
+    });
+
+    it('renders a fragment with the correct text including options', () => {
+      const MOCKED_RETURN_VALUE = `key: key options: ${JSON.stringify({
+        some: 'value',
+      })}`;
+      const wrapper = mount(
+        <FormattedMessage id="key" options={{ some: 'value' }} />
+      );
 
       expect(wrapper.contains(MOCKED_RETURN_VALUE)).toEqual(true);
     });
@@ -15,6 +25,7 @@ describe('<FormattedMessage />', () => {
 
   describe('when the component is passed a function as a child', () => {
     it('renders the return of the function with the correct text', () => {
+      const MOCKED_RETURN_VALUE = 'key: key options: undefined';
       const wrapper = mount(
         <FormattedMessage id="key">{text => <p>{text}</p>}</FormattedMessage>
       );


### PR DESCRIPTION
## What did we change?
We added a new component to represent the concept of a `FormattedDictionary` (name suggestions welcome!)
## Why are we doing this?
We've recently run into a few situations where we need to use the render props pattern to satisfy an interface, but have multiple translations we need to use. In order to solve this, we've resorted to [nesting render props](https://github.com/ezcater/pasta-react/pull/44/files#diff-8e4d577bce662b39b54159d7733c70da), which is visually noisy and not a great solution.

This new component would allow us to resolve multiple translations at once when using render props.

```jsx
<FormattedDictionary header="tips.modal.header" subheader="tips.modal.header">
     ({header, subheader}) => <EzModal header={header} subheader={subheader} />
</FormattedDictionary>
```

## How was it tested?

Included unit tests.