### PR TITLE
Only translate things that could be a translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18next-components",
-  "version": "1.2.0",
+  "version": "1.2.1",
   "description": "A collection of React components and utilities to simplify react-i18next",
   "main": "dist/index.js",
   "scripts": {

--- a/src/components/__tests__/FormattedDictionary.test.js
+++ b/src/components/__tests__/FormattedDictionary.test.js
@@ -20,6 +20,27 @@ describe('<FormattedDictionary />', () => {
       expect(wrapper.contains(<p>{MOCKED_RETURN_VALUE}</p>)).toEqual(true);
     });
 
+    it("doesn't include non-string params that may be provided by wrapping components", () => {
+      const MOCKED_RETURN_VALUE =
+        'key: name.key options: {} - key: header.key options: {}';
+      const wrapper = mount(
+        <FormattedDictionary
+          name="name.key"
+          header="header.key"
+          something={{ bad: 'value' }}
+        >
+          {({ name, header, something }) => (
+            <p>
+              {name} - {header}
+              {something}
+            </p>
+          )}
+        </FormattedDictionary>
+      );
+
+      expect(wrapper.contains(<p>{MOCKED_RETURN_VALUE}</p>)).toEqual(true);
+    });
+
     it('handles options being passed', () => {
       const MOCKED_RETURN_VALUE = `key: name.key options: {} - key: header.key options: ${JSON.stringify(
         { num: 4 }

--- a/src/formatters/formatDictionary.js
+++ b/src/formatters/formatDictionary.js
@@ -1,10 +1,13 @@
 import formatMessage from './formatMessage';
 
+const looksLikeATranslation = id => typeof id === 'string';
+
 export default (t, ids, options = {}) => {
   const translations = {};
-  Object.keys(ids).forEach(
-    key => (translations[key] = formatMessage(t, ids[key], options[key]))
-  );
+  Object.keys(ids).forEach(key => {
+    if (looksLikeATranslation(ids[key]))
+      translations[key] = formatMessage(t, ids[key], options[key]);
+  });
 
   return translations;
 };


### PR DESCRIPTION
## What did we change?
We now only attempt to translate things that look like they could be a translation. At the time of this PR, that just means they're a string. Maybe we can be smarter about that in the future.

## Why are we doing this?
Because in practice, sometimes this component gets wrapped with things that provide it boolean or object props. The translation function is fine with strings that don't have a translation, but it chokes on booleans.

## How was it tested?

Unit test to ensure no regressions and npm linked in a sample project.