### PR TITLE
Add typings

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.2.1",
   "description": "A collection of React components and utilities to simplify react-i18next",
   "main": "dist/index.js",
+  "typings": "types/index.d.ts",
   "scripts": {
     "test": "jest",
     "test:watch": "jest --watch",
@@ -41,6 +42,7 @@
     "@babel/preset-env": "^7.1.5",
     "@babel/preset-react": "^7.0.0",
     "@types/babel-core": "^6.25.5",
+    "@types/react": "^16.7.18",
     "babel-core": "^7.0.0-bridge.0",
     "babel-jest": "^23.6.0",
     "babel-loader": "^8.0.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-i18next-components",
-  "version": "1.2.1",
+  "version": "1.3.0",
   "description": "A collection of React components and utilities to simplify react-i18next",
   "main": "dist/index.js",
   "typings": "types/index.d.ts",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,40 @@
+import React from 'react';
+import { Moment } from 'moment';
+
+interface FormattedMessageProps {
+  id: string;
+  children?: (value: string) => React.ReactElement<any>;
+  options?: any;
+}
+
+interface FormattedDictionaryProps {
+  children: (value: any) => React.ReactElement<any>;
+  options?: any;
+  [props: string]: any;
+}
+
+interface FormattedDateTimeProps {
+  format?: String;
+  value: Number | String | Moment;
+}
+
+interface FormattedRelativeTimeProps {
+  value: Number | String | Moment;
+}
+
+export function FormattedMessage(
+  props: FormattedMessageProps
+): React.ReactElement<any>;
+export function FormattedDate(
+  props: FormattedDateTimeProps
+): React.ReactElement<any>;
+export function FormattedTime(
+  props: FormattedDateTimeProps
+): React.ReactElement<any>;
+export function FormattedDictionary(
+  props: FormattedDictionaryProps
+): React.ReactElement<any>;
+export function FormattedRelativeTime(
+  props: FormattedRelativeTimeProps
+): React.ReactElement<any>;
+export function configureI18n(args: any): any;


### PR DESCRIPTION
## What did we change?
We added a typescript typings file
## Why are we doing this?
So that new typescript projects can use this package without needing to define their own types. This will also prevent unintentional breaking changes since the library itself can be in control of its own types.
## How was it tested?
npm link in an existing typescript project.